### PR TITLE
Use /bin/sh instead of bash + optimize

### DIFF
--- a/fca.sh
+++ b/fca.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec rg -i -e md2 -e md4 -e md5 -e sha1 -e rc2 -e rc4 -e mersenne -e ecb -e 3des -e getpid -e srand $1
+exec rg -i -e 'md2|md4|md5|sha1|rc2|rc4|mersenne|ecb|3des|getpid|srand' $1

--- a/fca.sh
+++ b/fca.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
-rg -i -e md2 -e md4 -e md5 -e sha1 -e rc2 -e rc4 -e mersenne -e ecb -e 3des -e getpid -e srand $1
+#!/bin/sh
+exec rg -i -e md2 -e md4 -e md5 -e sha1 -e rc2 -e rc4 -e mersenne -e ecb -e 3des -e getpid -e srand $1


### PR DESCRIPTION
`bash` may not be available, and even when available, its path may not be `/bin`. For example, on BSD systems, `bash` will be installed as `/usr/local/bin/bash`.

Anyway, `bash` is not required here.

In addition, the shell can be replaced with `ripgrep` since nothing else depends on its output, and since `-e` matches regular expression, we can use a single one to match all the keywords.